### PR TITLE
use password attribute for password field

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -6,7 +6,7 @@
     <params>
         <param field="Address" label="IP Address" width="200px" required="true" default=""/>
         <param field="Username" label="Username" width="150px" required="true" default=""/>
-        <param field="Password" label="Password" width="150px" required="true" default=""/>
+        <param field="Password" label="Password" width="150px" required="true" default="" password="true"/>
         <param field="Mode6" label="Debug" width="75px">
             <options>
                 <option label="True" value="Debug" default="true"/>


### PR DESCRIPTION
this will cause the password to be hidden in the webif
support for the password attribute has been added in commit 8d290f216e5e25be48178ad30273129d2c84ad69

see https://domoticz.com/forum/viewtopic.php?f=65&t=23356&sid=94f0e8cf850c21853bd06c760ddfd5e7